### PR TITLE
Added routes with attributes

### DIFF
--- a/HttpServerLite/Routes/ReflectionCore.cs
+++ b/HttpServerLite/Routes/ReflectionCore.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace HttpServerLite.Routes
+{
+    public static class ReflectionCore
+    {
+        /// <summary>
+        /// Load routes from assembly
+        /// </summary>
+        /// <param name="server"></param>
+        /// <param name="assembly"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public static T LoadRoutes<T>(this T server, Assembly assembly = null) where T : Webserver 
+        {
+            var routes = (assembly ?? Assembly.GetCallingAssembly())
+                .GetTypes() // Get all classes from assembly
+                .SelectMany(x => x.GetMethods()) // Get all methods from assembly
+                .Where(IsValidRoute); // Only select methods that are valid routes
+
+            foreach (var route in routes)
+            {
+                var attribute = route.GetCustomAttributes().OfType<Route>().First();
+                server.StaticRoutes.Add(attribute.HttpMethod, attribute.RouteName, route.ToRouteMethod());
+            }
+
+            return server;
+        }
+
+        /// <summary>
+        /// Determines whether method is a valid route-method
+        /// </summary>
+        /// <param name="method"></param>
+        /// <returns>true when method is valid</returns>
+        private static bool IsValidRoute(MethodInfo method)
+            => method.GetCustomAttributes().OfType<Route>().Any() // Must have the Route attribute
+               && method.ReturnType == typeof(Task)
+               && method.GetParameters().Length == 1
+               && method.GetParameters().First().ParameterType == typeof(HttpContext); 
+
+        /// <summary>
+        /// Create delegate method from methodInfo
+        /// </summary>
+        /// <param name="method"></param>
+        /// <returns>static route method</returns>
+        private static Func<HttpContext, Task> ToRouteMethod(this MethodInfo method)
+        {
+            if (method.IsStatic)
+                return (Func<HttpContext, Task>) Delegate.CreateDelegate(typeof(Func<HttpContext, Task>), method);
+            else
+            {
+                object classInstance =
+                    Activator.CreateInstance(method.DeclaringType ?? throw new Exception("Declaring class is null"));
+                return (Func<HttpContext, Task>) Delegate.CreateDelegate(typeof(Func<HttpContext, Task>), classInstance,
+                    method);
+            }
+        }
+    }
+}

--- a/HttpServerLite/Routes/Route.cs
+++ b/HttpServerLite/Routes/Route.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace HttpServerLite.Routes
+{
+    /// <summary>
+    /// Attribute that is used to mark methods as route-methods
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method)]
+    public sealed class Route : Attribute
+    {
+        public string RouteName { get; }
+        public HttpMethod HttpMethod { get; }
+        
+        /// <summary></summary>
+        /// <param name="routeName"></param>
+        /// <param name="httpMethod"></param>
+        public Route(string routeName, HttpMethod httpMethod = HttpMethod.GET)
+        {
+            RouteName = routeName;
+            HttpMethod = httpMethod;
+        }
+    }
+}

--- a/Test/Program.cs
+++ b/Test/Program.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using HttpServerLite;
+using HttpServerLite.Routes;
 
 namespace Test
 {
@@ -14,7 +15,8 @@ namespace Test
 
         static void Main(string[] args)
         {
-            _Server = new Webserver("localhost", 9000, false, null, null, DefaultRoute);
+            _Server = new Webserver("localhost", 9000, false, null, null, DefaultRoute)
+                .LoadRoutes();
             _Server.DefaultHeaders.Host = "http://localhost:9000";
             // _Server.Events.ConnectionReceived = ConnectionReceived;
             _Server.Start();
@@ -104,6 +106,15 @@ namespace Test
 
             ctx.Response.ContentLength = resp.Length;
             await ctx.Response.SendAsync(resp);
+        }
+
+        [Route("Test")]
+        public async Task TestRoute(HttpContext context)
+        {
+            byte[] response = Encoding.UTF8.GetBytes("HttpServerLite test route");
+            context.Response.StatusCode = 200;
+            context.Response.ContentType = "text/html";
+            await context.Response.SendAsync(response);
         }
     }
 }


### PR DESCRIPTION
Added support for routes with attributes that are automatically loaded with reflection when calling `.LoadRoutes()`

Example:
```cs
using System;
using System.IO;
using System.Text;
using System.Threading;
using System.Threading.Tasks;
using HttpServerLite;
using HttpServerLite.Routes;

namespace Test
{
    class Program
    {
        static void Main(string[] args)
        {
            var server = new Webserver("localhost", 9000, false, null, null, DefaultRoute)
                .LoadRoutes();
            server.DefaultHeaders.Host = "http://localhost:9000";
            server.Start();
            
            Console.WriteLine("http://localhost:9000");
            Console.WriteLine("ENTER to exit");
            Console.ReadLine();
        }

        static async Task DefaultRoute(HttpContext context)
        {
            byte[] response = Encoding.UTF8.GetBytes("HttpServerLite default route");
            context.Response.StatusCode = 200;
            context.Response.ContentType = "text/html";
            await context.Response.SendAsync(response); 
        }

        [Route("Test")]
        public async Task TestRoute(HttpContext context)
        {
            byte[] response = Encoding.UTF8.GetBytes("HttpServerLite test route");
            context.Response.StatusCode = 200;
            context.Response.ContentType = "text/html";
            await context.Response.SendAsync(response);
        }
    }
}
```