### PR TITLE
adding X509Certificate2 to ctor

### DIFF
--- a/HttpServerLite/HttpServerLite.csproj
+++ b/HttpServerLite/HttpServerLite.csproj
@@ -79,7 +79,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CavemanTcp" Version="1.3.8.3" />
+    <PackageReference Include="CavemanTcp" Version="1.3.10" />
     <PackageReference Include="IpMatcher" Version="1.0.4.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="RegexMatcher" Version="1.0.7.1" />

--- a/HttpServerLite/HttpServerLite.xml
+++ b/HttpServerLite/HttpServerLite.xml
@@ -1378,13 +1378,14 @@
             </summary>
             <param name="settings">Webserver settings.</param>
         </member>
-        <member name="M:HttpServerLite.Webserver.#ctor(System.String,System.Int32,System.Func{HttpServerLite.HttpContext,System.Threading.Tasks.Task})">
+        <member name="M:HttpServerLite.Webserver.#ctor(System.String,System.Int32,System.Func{HttpServerLite.HttpContext,System.Threading.Tasks.Task},System.Security.Cryptography.X509Certificates.X509Certificate2)">
             <summary>
-            Instantiate the webserver without SSL.
+            Instantiate the webserver with or without SSL.
             </summary>
             <param name="hostname">Hostname or IP address on which to listen.</param>
             <param name="port">TCP port on which to listen.</param>
             <param name="defaultRoute">Default route.</param>
+            <param name="sslCertificate">For SSL, the certificate.</param>
         </member>
         <member name="M:HttpServerLite.Webserver.#ctor(System.String,System.Int32,System.Boolean,System.String,System.String,System.Func{HttpServerLite.HttpContext,System.Threading.Tasks.Task})">
             <summary>
@@ -1679,6 +1680,11 @@
         <member name="F:HttpServerLite.WebserverSettings.SslSettings.Enable">
             <summary>
             Enable or disable SSL.
+            </summary>
+        </member>
+        <member name="F:HttpServerLite.WebserverSettings.SslSettings.sslCertificate">
+            <summary>
+            Certifcate for SSL.
             </summary>
         </member>
         <member name="F:HttpServerLite.WebserverSettings.SslSettings.PfxCertificateFile">

--- a/HttpServerLite/WebserverSettings.cs
+++ b/HttpServerLite/WebserverSettings.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Security.Cryptography.X509Certificates;
 
 namespace HttpServerLite
 {
@@ -240,6 +241,11 @@ namespace HttpServerLite
             /// Enable or disable SSL.
             /// </summary>
             public bool Enable = false;
+
+            /// <summary>
+            /// Certifcate for SSL.
+            /// </summary>
+            public X509Certificate2 sslCertificate = null;
 
             /// <summary>
             /// PFX certificate filename.


### PR DESCRIPTION
Following the changes on CavemanTcp: using X509Certificate2 on ctor