### PR TITLE
Added exception handling inside the catch logic on the client connected event

### DIFF
--- a/src/HttpServerLite/Webserver.cs
+++ b/src/HttpServerLite/Webserver.cs
@@ -729,7 +729,15 @@ namespace HttpServerLite
                 {
                     ctx.Response.StatusCode = 500;
                     ctx.Response.ContentType = _Pages.Default500Page.ContentType;
-                    await ctx.Response.SendAsync(_Pages.Default500Page.Content, _Token).ConfigureAwait(false);
+                    try
+                    {
+                        await ctx.Response.SendAsync(_Pages.Default500Page.Content, _Token).ConfigureAwait(false);
+                    }
+                    catch
+                    {
+                        // ignored
+                        //Exception here it's due to client already disconnected, so we can't send the error page and we just ignore it to avoid a crash
+                    }
 
                     _Events.HandleException(this, new ExceptionEventArgs(ctx, e));
                 }


### PR DESCRIPTION
This solve a problem when the exception being caught it's due to client disconnected, so the sendAsync will throw other exception that will propagate and cause a unhandled exception and crash the application.